### PR TITLE
Update version to 4.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.13
 
-ENV POWERDNS_RECURSOR_VERSION=4.3.5
+ENV POWERDNS_RECURSOR_VERSION=4.4.2
 
 RUN set -ex \
     && apk --no-cache add \

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@ PowerDNS Recursor on Alpine Linux
 ---
 
 Official website: <https://powerdns.com>  
-Current version: **4.3.5**
+Current version: **4.4.2**
 
-![](https://img.shields.io/microbadger/layers/magnaz/powerdns-recursor/4.3.5) ![](https://img.shields.io/docker/image-size/magnaz/powerdns-recursor/4.3.5)
+![](https://img.shields.io/microbadger/layers/magnaz/powerdns-recursor/4.4.2) ![](https://img.shields.io/docker/image-size/magnaz/powerdns-recursor/4.4.2)
 
 ### Available tags:
- - 4.3.5, 4.3, latest
+ - 4.4.2, 4.4, latest
+ - 4.3.5, 4.3
  - 4.3.4
  - 4.3.3
  - 4.3.0


### PR DESCRIPTION
https://blog.powerdns.com/2020/12/14/powerdns-recursor-4-4-2-released/